### PR TITLE
fixed the bug in the link for Ghana

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you have an awesome dataset, API link or a project link related to COVID-19 a
 * ![OK_ICON](https://github.com/sfu-db/covid19-datasets/blob/master/assets/ok_icon.png)[Italy COVID-19 Case Data with Basemap (STC)](/datasets-details/Italy-COVID-19-Case-Data-with-Basemap-(STC).md)
 * ![OK_ICON](https://github.com/sfu-db/covid19-datasets/blob/master/assets/ok_icon.png)[Brazil COVID-19 Case Data with Basemap (STC)](/datasets-details/Brazil-COVID-19-Case-Data-with-Basemap-(STC).md)
 * ![OK_ICON](https://github.com/sfu-db/covid19-datasets/blob/master/assets/ok_icon.png)[COVID-19 in Japan Dataset](/datasets-details/Japan.md)
-* ![OK_ICON](https://github.com/sfu-db/covid19-datasets/blob/master/assets/ok_icon.png)[COVID-19 in Ghana Dataset](https://github.com/sfu-db/covid19-datasets/blob/master/datasets-details/Brazil-COVID-19-Case-Data-with-Basemap-(STC).md)
+* ![OK_ICON](https://github.com/sfu-db/covid19-datasets/blob/master/assets/ok_icon.png)[COVID-19 in Ghana Dataset](https://github.com/sfu-db/covid19-datasets/blob/master/datasets-details/Ghana.md)
 * ![OK_ICON](https://github.com/sfu-db/covid19-datasets/blob/master/assets/ok_icon.png)[COVID-19 in Spain Dataset](/datasets-details/COVID-19-in-Spain-Dataset.md)
 * ![OK_ICON](https://github.com/sfu-db/covid19-datasets/blob/master/assets/ok_icon.png)[Detection of COVID-19 using Raman Spectroscopy](/datasets-details/raman_spectroscopy_covid19_detection.md)
 


### PR DESCRIPTION
The link for the ghana wasn't correct in the root README.md file. It was redirecting towards brazil covid19 readme.md file.
Fixed this issue in this PR.